### PR TITLE
vue.js에 레이아웃 추가

### DIFF
--- a/project/src/App.vue
+++ b/project/src/App.vue
@@ -1,22 +1,31 @@
 <template>
+  <div class="app-container">
+    <TheSidebarLogin />
+    <RouterView />
+  </div>
   <ModalAddPost />
   <ModalEditPost />
   <ModalExpenditure />
   <ModalImport />
-  <!-- <TheSidebar /> -->
-  <!-- <RouterView /> -->
 </template>
-
 <script>
+import TheSidebarLogin from '@/layouts/TheSidebarLogin.vue'
+
 import ModalAddPost from './components/modal/ModalAddPost.vue'
 import ModalEditPost from './components/modal/ModalEditPost.vue'
 import ModalExpenditure from '@/components/modal/ModalExpenditure.vue'
 import ModalImport from '@/components/modal/ModalImport.vue'
 
-// import TheSidebar from '@/layouts/TheSidebar.vue'
 export default {
   name: 'App',
-  components: { ModalAddPost, ModalEditPost, ModalExpenditure, ModalImport },
-
+  components: { TheSidebarLogin, ModalAddPost, ModalEditPost, ModalExpenditure, ModalImport },
 }
 </script>
+<style scoped>
+.app-container {
+  display: flex;
+  flex-direction: row; /*수평 정렬*/
+  align-items: flex-start;
+  height: 100vh;
+}
+</style>


### PR DESCRIPTION
### [#14 ] 기능 구현 제목

## 개요

화면 왼쪽에 nav바, 오른쪽에 해당 페이지가 오도록 레이아웃 위치 잡기

## PR 유형

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드 리팩토링
- [ ] 코드에 영향 없는 수정
- [ ] 문서 수정
- [ ] 테스트 추가/리팩토링
- [ ] 빌드/패키지 관련
- [ ] 파일/폴더명 수정
- [ ] 파일 삭제

## PR Checklist

- [x] 커밋 메시지 컨벤션을 지켰나요?
- [x] 기능 테스트를 완료했나요?
- [x] main 브랜치로 머지 요청했나요?

## 테스트 결과 (캡쳐이미지)
<nav바가 왼쪽에 고정되어 있고 / 오른쪽에 라우터된 화면이 변경 됨>
<img width="1713" alt="스크린샷 2025-04-10 오후 12 59 56" src="https://github.com/user-attachments/assets/cdba34b1-d839-43ff-a4a5-2d4bde9eaeb7" />

<모달 버튼 (아직 위치 조정 전 -> 추후 수정 예정)>
<img width="124" alt="스크린샷 2025-04-10 오후 1 00 53" src="https://github.com/user-attachments/assets/b0ae1eb2-140f-4b8d-8d89-e8e13dc7c2a8" />

fixes #14 